### PR TITLE
Revise conversion.lua, anthracite.lua

### DIFF
--- a/anthracite.lua
+++ b/anthracite.lua
@@ -12,7 +12,7 @@ minetest.register_node(modname .. ":anthracite", {
 		groups = {
 			coal = 1,
 			stone = 1,
-			lignite = 1,
+			anthracite = 1,
 			cracky = 3,
 			flammable = 50,
 			fire_fuel = 8

--- a/conversion.lua
+++ b/conversion.lua
@@ -6,7 +6,7 @@ local modname = minetest.get_current_modname()
 ---------------------------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------------------------
-minetest.register_alias("nc_lignite:stone",					modname .. ":lignite")
+minetest.register_alias("nc_lignite:stone",				modname .. ":lignite")
 ---------------------------------------------------------------------------------------------------
 minetest.register_alias("nc_lignite:stone_1",				modname .. ":lignite")
 minetest.register_alias("nc_lignite:stone_2",				modname .. ":lignite")
@@ -16,10 +16,12 @@ minetest.register_alias("nc_lignite:stone_5",				modname .. ":lignite")
 minetest.register_alias("nc_lignite:stone_6",				modname .. ":lignite")
 minetest.register_alias("nc_lignite:stone_7",				modname .. ":lignite")
 ---------------------------------------------------------------------------------------------------
-minetest.register_alias("nc_lignite:cobble",					modname .. ":bituminite")
-minetest.register_alias("nc_lignite:cobble_loose",			modname .. ":bituminite")
+minetest.register_alias("nc_lignite:cobble",				modname .. ":lignite")
+minetest.register_alias("nc_lignite:cobble_loose",			modname .. ":lignite_loose")
 ---------------------------------------------------------------------------------------------------
-minetest.register_alias("nc_lignite:ore",					modname .. ":anthracite")
+minetest.register_alias("nc_lignite:ore",				modname .. ":lignite")
+---------------------------------------------------------------------------------------------------
+minetest.register_alias("nc_lignite:coal_dust",				"nc_writing:glyph3")
 ---------------------------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------------------------
 ---------------------------------------------------------------------------------------------------

--- a/discovery.lua
+++ b/discovery.lua
@@ -33,6 +33,6 @@ nodecore.register_hint("dig anthracite",
 )
 
 nodecore.register_hint("break lignite, bituminite, or anthracite into chunks",
-	"refine loose coal",
-	"group:wcoal"
+	{true, "refine loose coal", "refine packed coal"},
+	"group:lump_coal"
 )


### PR DESCRIPTION
Conversion: change would deny gain of new previously unmined objects and solves coal dust where captured by player.  Instead of spreading out the variation in lignite mod with coal varieties, I feel that keeping lignite forms in the coal mod is more appropriate.

Anthracite: Presently a successful discovery of lignite prevents discovery of anthracite, or the reverse because discovery of anthracite was considered, reported as lignite.